### PR TITLE
Use hashed seed for sky generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-	id 'fabric-loom' version '0.12-SNAPSHOT'
-	id 'io.github.juuxel.loom-quiltflower' version '1.7.1'	// to use genSourcesWithQuiltflower
+	id 'fabric-loom' version '1.0-SNAPSHOT'
+	id 'io.github.juuxel.loom-quiltflower' version '1.8.0'	// to use genSourcesWithQuiltflower
 	id "me.champeau.jmh" version "0.6.6"
 }
 
@@ -29,10 +29,8 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	mappings loom.layered {
+		it.officialMojangMappings()
 		it.parchment("org.parchmentmc.data:parchment-1.19.2:2022.08.10@zip") // https://ldtteam.jfrog.io/ui/native/parchmentmc-public/org/parchmentmc/data/parchment-1.18.1/BLEEDING-SNAPSHOT
-		it.officialMojangMappings {
-			setNameSyntheticMembers(false)
-		}
 	}
 
 	// apis
@@ -41,7 +39,7 @@ dependencies {
 	// devenv mods
 	modRuntimeOnly "maven.modrinth:lazydfu:${project.lazydfu_version}"
 	modRuntimeOnly "maven.modrinth:starlight:${project.starlight_version}"
-	modRuntimeOnly "maven.modrinth:lithium:${project.lithium_version}"
+	//modRuntimeOnly "maven.modrinth:lithium:${project.lithium_version}"
 	modRuntimeOnly "maven.modrinth:spark:${project.spark_version}"
 	modRuntimeOnly include(fabricApi.module("fabric-command-api-v2", project.fabric_version))
 	modRuntimeOnly include(fabricApi.module("fabric-lifecycle-events-v1", project.fabric_version))

--- a/src/main/java/codes/ztereohype/nicerskies/IClientLevelAccessor.java
+++ b/src/main/java/codes/ztereohype/nicerskies/IClientLevelAccessor.java
@@ -1,0 +1,5 @@
+package codes.ztereohype.nicerskies;
+
+public interface IClientLevelAccessor {
+    long nicerSkies_getHashedSeed();
+}

--- a/src/main/java/codes/ztereohype/nicerskies/core/NebulaSeedManager.java
+++ b/src/main/java/codes/ztereohype/nicerskies/core/NebulaSeedManager.java
@@ -1,18 +1,16 @@
 package codes.ztereohype.nicerskies.core;
 
+import codes.ztereohype.nicerskies.IClientLevelAccessor;
 import net.minecraft.client.Minecraft;
-import net.minecraft.world.level.Level;
-
-import java.util.Objects;
 
 public class NebulaSeedManager {
     public static long getSeed() {
-        if (Minecraft.getInstance().hasSingleplayerServer()) {
-            // calculate seed from overworld seed
-            return Objects.hash(Minecraft.getInstance().getSingleplayerServer().getLevel(Level.OVERWORLD).getSeed());
-        } else {
-            return Objects.requireNonNull(Minecraft.getInstance().getCurrentServer()).ip.hashCode();
+
+        // Use hashed seed. This is available in
+        if (Minecraft.getInstance().level != null) {
+            return ((IClientLevelAccessor) Minecraft.getInstance().level).nicerSkies_getHashedSeed();
         }
+        return 0;
     }
 
     public static boolean canGetSeed() {

--- a/src/main/java/codes/ztereohype/nicerskies/mixin/ClientLevelMixin.java
+++ b/src/main/java/codes/ztereohype/nicerskies/mixin/ClientLevelMixin.java
@@ -1,0 +1,32 @@
+package codes.ztereohype.nicerskies.mixin;
+
+import codes.ztereohype.nicerskies.IClientLevelAccessor;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.core.Holder;
+import net.minecraft.resources.ResourceKey;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.function.Supplier;
+
+@Mixin(ClientLevel.class)
+public class ClientLevelMixin implements IClientLevelAccessor {
+
+    @Unique
+    private long hashedSeed;
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void generateSkies(ClientPacketListener clientPacketListener, ClientLevel.ClientLevelData clientLevelData, ResourceKey resourceKey, Holder holder, int i, int j, Supplier supplier, LevelRenderer levelRenderer, boolean bl, long hashedSeed, CallbackInfo ci) {
+        this.hashedSeed = hashedSeed;
+    }
+
+    @Override
+    public long nicerSkies_getHashedSeed() {
+        return hashedSeed;
+    }
+}

--- a/src/main/resources/nicer_skies.mixins.json
+++ b/src/main/resources/nicer_skies.mixins.json
@@ -7,7 +7,8 @@
   "client": [
     "MinecraftMixin",
     "MixinLightTexutre",
-    "MixinStarRendering"
+    "MixinStarRendering",
+    "ClientLevelMixin"
   ],
   "server": [],
   "injectors": {


### PR DESCRIPTION
Hashed seed is world-seed dependent and available in both singleplayer and multiplayer.  

Also, I believe, this would fix #2 (and make the sky constant)
